### PR TITLE
Remove docker desktop sourcing from zshrc

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -107,5 +107,3 @@ export KUBECTL_EXTERNAL_DIFF="dyff between --omit-header --set-exit-code"
 alias vim="nvim"
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
-
-source /Users/kristinn/.docker/init-zsh.sh || true # Added by Docker Desktop


### PR DESCRIPTION
This doesn't seem to be added anymore, so let's remove it from the config